### PR TITLE
Add placeholders and error messages to user registration form

### DIFF
--- a/vehicleminders_app/app/assets/stylesheets/custom.scss
+++ b/vehicleminders_app/app/assets/stylesheets/custom.scss
@@ -452,3 +452,8 @@ table {
   display: inline-block;
   margin: 13px 0;
 }
+
+.required::after {
+  content: "*";
+  color: red;
+}

--- a/vehicleminders_app/app/controllers/users_controller.rb
+++ b/vehicleminders_app/app/controllers/users_controller.rb
@@ -27,9 +27,9 @@ class UsersController < ApplicationController
       reset_session
       log_in @user
       flash[:success] = 'ユーザー登録が完了しました。'
-      redirect_to @user
+      redirect_to menu_path(@user)
     else
-      render 'new'
+      render 'new', status: :unprocessable_entity
     end
   end
 
@@ -43,7 +43,7 @@ class UsersController < ApplicationController
       flash[:success] = 'プロフィールを更新しました。'
       redirect_to menu_path(@user)
     else
-      render 'edit'
+      render 'edit', status: :unprocessable_entity
     end
   end
 

--- a/vehicleminders_app/app/views/shared/_error_messages.html.erb
+++ b/vehicleminders_app/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,9 @@
 <% if @user.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
-      The form contains <%= pluralize(@user.errors.count, "error") %>.
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
     </div>
-    <ul>
-    <% @user.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-    <% end %>
-    </ul>
   </div>
 <% end %>

--- a/vehicleminders_app/app/views/users/_form.html.erb
+++ b/vehicleminders_app/app/views/users/_form.html.erb
@@ -1,20 +1,20 @@
 <%= form_with(model: @user, class: 'form-center') do |f| %>
   <%= render 'shared/error_messages', object: @user %>
 
-  <%= f.label :名前 %>
-  <%= f.text_field :name, class: 'form-control' %>
+  <%= f.label :名前, class: 'required' %>
+  <%= f.text_field :name, class: 'form-control', required: true %>
 
-  <%= f.label :メールアドレス %>
-  <%= f.email_field :email, class: 'form-control' %>
+  <%= f.label :メールアドレス, class: 'required' %>
+  <%= f.email_field :email, class: 'form-control', required: true %>
 
-  <%= f.label :Webhook_URL %>
+  <%= f.label :webhook_url, 'Microsoft TeamsのWebhook URL' %>
   <%= f.text_field :webhook_url, class: 'form-control' %>
 
-  <%= f.label :パスワード %>
-  <%= f.password_field :password, class: 'form-control' %>
+  <%= f.label :パスワード, class: 'required' %>
+  <%= f.password_field :password, class: 'form-control', placeholder: '6文字以上のパスワードを設定してください', required: true %>
 
-  <%= f.label :パスワード確認用 %>
-  <%= f.password_field :password_confirmation, class: 'form-control' %>
+  <%= f.label :パスワード確認用, class: 'required' %>
+  <%= f.password_field :password_confirmation, class: 'form-control', placeholder: 'パスワードを再入力してください', required: true %>
 
   <%= f.label :メールで通知する %>
   <%= f.check_box :email_notification, class: 'form-checkbox' %>

--- a/vehicleminders_app/config/locales/ja.yml
+++ b/vehicleminders_app/config/locales/ja.yml
@@ -1,13 +1,14 @@
 ja:
-  helpers:
-    page_entries_info:
-      more_pages:
-        display_entries: "<b>%{total}</b>中の%{entry_name}を表示しています <b>%{first} - %{last}</b>"
-      one_page:
-        display_entries:
-          one: "<b>%{count}</b>レコード表示中です %{entry_name}"
-          other: "<b>%{count}</b>レコード表示中です %{entry_name}"
-          zero: "レコードが見つかりませんでした %{entry_name}"
+  activerecord:
+    attributes:
+      user:
+        password: "パスワード"
+    errors:
+      models:
+        user:
+          attributes:
+            password:
+              too_short: "は6文字以上にしてください"
   views:
     pagination:
       first: "&laquo; 最初"


### PR DESCRIPTION
5文字以内のパスワードを登録したときに、エラーメッセージが出るように設定。
プレイスホルダーを入力欄に追加することでユーザービリティを向上。